### PR TITLE
fix fire tower killing enemy bug

### DIFF
--- a/Assets/Scripts/Waves/Enemy.cs
+++ b/Assets/Scripts/Waves/Enemy.cs
@@ -82,17 +82,8 @@ public class Enemy : MonoBehaviour
     }
     
     public void TakeDamage(int amount, string towerType = "Neutral") {
-
         int finalDamage = CalculateDamage(amount, towerType);
         health -= finalDamage;
-
-        if (health <= 0) {
-            WaveTracker.EnemyKilled();
-            WaveTracker.UnregisterEnemy(this);
-            Destroy(gameObject);
-            Fortress.gold += 10;
-        }
-
     }
 
     private int CalculateDamage(int baseDamage, string towerType)
@@ -188,7 +179,13 @@ public class Enemy : MonoBehaviour
     }
 
     private void Update() {
-
+        if (health <= 0) {
+            WaveTracker.EnemyKilled();
+            WaveTracker.UnregisterEnemy(this);
+            Destroy(gameObject);
+            Fortress.gold += 10;
+        }
+        
         if (Vector3.Distance(target.position, transform.position) <= 1f) {
 
             pathIndex++;


### PR DESCRIPTION
fix fire tower killing enemy bug
The problem was that each damage instance was able to report a dead enemy.
It counted an enemy dying twice (fire tower) due to it dying to base bullet damage and burn damage.

Fix was to move the health <= 0 check to the update() method