### PR TITLE
Tower Range Indicator

### DIFF
--- a/Assets/Prefabs/Towers/Earth Wizard.prefab
+++ b/Assets/Prefabs/Towers/Earth Wizard.prefab
@@ -28,7 +28,7 @@ Transform:
   m_GameObject: {fileID: 3331757315967049371}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0, y: 1, z: 0}
+  m_LocalPosition: {x: -0, y: 1.81, z: 0}
   m_LocalScale: {x: 0.8, y: 0.5, z: 0.8}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -130,7 +130,7 @@ Transform:
   m_GameObject: {fileID: 3551737492471203513}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.5, y: 0.6666666, z: 0.5}
+  m_LocalPosition: {x: 0.5, y: 1.476667, z: 0.5}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -185,14 +185,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1fd0dee9c03ae934fa38f7361b56f521, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Defaultrange: 20
-  DefaultfireRate: 1.25
+  range: 20
+  fireRate: 1
   path: 0
   rank: 0
   cost: 50
   sellValue: 0
-  range: 10
-  fireRate: 1
   targeting: First
   towerName: Earth Wizard
   tilePlacedOn: {fileID: 0}
@@ -228,7 +226,7 @@ BoxCollider:
   m_Enabled: 1
   serializedVersion: 3
   m_Size: {x: 0.81, y: 2.01, z: 0.81}
-  m_Center: {x: 0, y: 0.25, z: 0}
+  m_Center: {x: 0, y: 1.06, z: 0}
 --- !u!1 &6979538598005272271
 GameObject:
   m_ObjectHideFlags: 0
@@ -257,7 +255,7 @@ Transform:
   m_GameObject: {fileID: 6979538598005272271}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 0.81, z: 0}
   m_LocalScale: {x: 0.8, y: 1.5, z: 0.8}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -362,7 +360,7 @@ Transform:
   m_GameObject: {fileID: 7537032571374466112}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.5, y: 0.33333334, z: 0.5}
+  m_LocalPosition: {x: 0.5, y: 1.143333, z: 0.5}
   m_LocalScale: {x: 0.2, y: 0.7, z: 0.2}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/Assets/Prefabs/Towers/Fire Wizard.prefab
+++ b/Assets/Prefabs/Towers/Fire Wizard.prefab
@@ -49,20 +49,27 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1fd0dee9c03ae934fa38f7361b56f521, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Defaultrange: 20
-  DefaultfireRate: 1.25
-  rank: 0
-  towerName: Fire Wizard
-  range: 10
+  range: 20
   fireRate: 1.25
+  path: 0
+  rank: 0
   cost: 50
-  targeting: First
   sellValue: 0
+  targeting: First
+  towerName: Fire Wizard
   tilePlacedOn: {fileID: 0}
+  damage: 40
+  bulletSpeed: 0
+  stunDuration: 1
+  burnDuration: 3
+  burnDamage: 5
+  critChance: 0.2
+  critDamage: 1.5
+  splashRadius: 20
   enemyTag: Enemy
   turnSpeed: 10
-  bulletPrefab: {fileID: 4532496019053226831, guid: adca3e0cf47b11846b087013382d991c, type: 3}
   firePoint: {fileID: 6474012755518759597}
+  bulletPrefab: {fileID: 4532496019053226831, guid: adca3e0cf47b11846b087013382d991c, type: 3}
 --- !u!65 &-7232503826309692804
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -83,7 +90,7 @@ BoxCollider:
   m_Enabled: 1
   serializedVersion: 3
   m_Size: {x: 0.81, y: 2.01, z: 0.81}
-  m_Center: {x: 0, y: 0.25, z: 0}
+  m_Center: {x: 0, y: 1.06, z: 0}
 --- !u!1 &4725472580218646531
 GameObject:
   m_ObjectHideFlags: 0
@@ -109,7 +116,7 @@ Transform:
   m_GameObject: {fileID: 4725472580218646531}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.5, y: 0.6666666, z: 0.5}
+  m_LocalPosition: {x: 0.5, y: 1.476667, z: 0.5}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -143,7 +150,7 @@ Transform:
   m_GameObject: {fileID: 5660257461959272123}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.5, y: 0.33333334, z: 0.5}
+  m_LocalPosition: {x: 0.5, y: 1.143333, z: 0.5}
   m_LocalScale: {x: 0.2, y: 0.7, z: 0.2}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -248,7 +255,7 @@ Transform:
   m_GameObject: {fileID: 7980325151398033861}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0, y: 1, z: 0}
+  m_LocalPosition: {x: -0, y: 1.81, z: 0}
   m_LocalScale: {x: 0.8, y: 0.5, z: 0.8}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -353,7 +360,7 @@ Transform:
   m_GameObject: {fileID: 9205358739210879603}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 0.81, z: 0}
   m_LocalScale: {x: 0.8, y: 1.5, z: 0.8}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/Assets/Prefabs/Towers/Water Wizard.prefab
+++ b/Assets/Prefabs/Towers/Water Wizard.prefab
@@ -49,20 +49,27 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1fd0dee9c03ae934fa38f7361b56f521, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Defaultrange: 20
-  DefaultfireRate: 1.25
-  rank: 0
-  towerName: Water Wizard
-  range: 10
+  range: 20
   fireRate: 1.25
+  path: 0
+  rank: 0
   cost: 50
-  targeting: First
   sellValue: 0
+  targeting: First
+  towerName: Water Wizard
   tilePlacedOn: {fileID: 0}
+  damage: 40
+  bulletSpeed: 0
+  stunDuration: 1
+  burnDuration: 3
+  burnDamage: 5
+  critChance: 0.2
+  critDamage: 1.5
+  splashRadius: 20
   enemyTag: Enemy
   turnSpeed: 10
-  bulletPrefab: {fileID: 741375603087042898, guid: 1cc61a22bdb063040a82eb3873368d4f, type: 3}
   firePoint: {fileID: 8465691569154119655}
+  bulletPrefab: {fileID: 741375603087042898, guid: 1cc61a22bdb063040a82eb3873368d4f, type: 3}
 --- !u!65 &1930666961851625833
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -83,7 +90,7 @@ BoxCollider:
   m_Enabled: 1
   serializedVersion: 3
   m_Size: {x: 0.81, y: 2.01, z: 0.81}
-  m_Center: {x: 0, y: 0.25, z: 0}
+  m_Center: {x: 0, y: 1.06, z: 0}
 --- !u!1 &2531057562103784457
 GameObject:
   m_ObjectHideFlags: 0
@@ -112,7 +119,7 @@ Transform:
   m_GameObject: {fileID: 2531057562103784457}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0, y: 1, z: 0}
+  m_LocalPosition: {x: -0, y: 1.81, z: 0}
   m_LocalScale: {x: 0.8, y: 0.5, z: 0.8}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -217,7 +224,7 @@ Transform:
   m_GameObject: {fileID: 3751018790601649578}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.5, y: 0.33333334, z: 0.5}
+  m_LocalPosition: {x: 0.5, y: 1.143333, z: 0.5}
   m_LocalScale: {x: 0.2, y: 0.7, z: 0.2}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -322,7 +329,7 @@ Transform:
   m_GameObject: {fileID: 4278663885727058208}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 0.81, z: 0}
   m_LocalScale: {x: 0.8, y: 1.5, z: 0.8}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -424,7 +431,7 @@ Transform:
   m_GameObject: {fileID: 6633699600417205546}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.5, y: 0.6666666, z: 0.5}
+  m_LocalPosition: {x: 0.5, y: 1.476667, z: 0.5}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/Assets/Prefabs/Towers/Wind Wizard.prefab
+++ b/Assets/Prefabs/Towers/Wind Wizard.prefab
@@ -49,14 +49,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1fd0dee9c03ae934fa38f7361b56f521, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Defaultrange: 20
-  DefaultfireRate: 1.25
+  range: 20
+  fireRate: 1.4
   path: 0
   rank: 0
   cost: 50
   sellValue: 0
-  range: 10
-  fireRate: 1.4
   targeting: First
   towerName: Wind Wizard
   tilePlacedOn: {fileID: 0}
@@ -92,7 +90,7 @@ BoxCollider:
   m_Enabled: 1
   serializedVersion: 3
   m_Size: {x: 0.81, y: 2.01, z: 0.81}
-  m_Center: {x: 0, y: 0.25, z: 0}
+  m_Center: {x: 0, y: 1.06, z: 0}
 --- !u!1 &2784123222127386913
 GameObject:
   m_ObjectHideFlags: 0
@@ -121,7 +119,7 @@ Transform:
   m_GameObject: {fileID: 2784123222127386913}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0, y: 1, z: 0}
+  m_LocalPosition: {x: -0, y: 1.81, z: 0}
   m_LocalScale: {x: 0.8, y: 0.5, z: 0.8}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -226,7 +224,7 @@ Transform:
   m_GameObject: {fileID: 4109827456189958537}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.5, y: 0.33333334, z: 0.5}
+  m_LocalPosition: {x: 0.5, y: 1.143333, z: 0.5}
   m_LocalScale: {x: 0.2, y: 0.7, z: 0.2}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -331,7 +329,7 @@ Transform:
   m_GameObject: {fileID: 4380450204584603618}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 0.81, z: 0}
   m_LocalScale: {x: 0.8, y: 1.5, z: 0.8}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -433,7 +431,7 @@ Transform:
   m_GameObject: {fileID: 4569330739509077400}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.5, y: 0.6666666, z: 0.5}
+  m_LocalPosition: {x: 0.5, y: 1.476667, z: 0.5}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/Assets/Scenes/Level 1.unity
+++ b/Assets/Scenes/Level 1.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 705507994}
-  m_IndirectSpecularColor: {r: 0.17338729, g: 0.21673925, b: 0.2988084, a: 1}
+  m_IndirectSpecularColor: {r: 0.17338742, g: 0.21673962, b: 0.29880893, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -1102,7 +1102,7 @@ MonoBehaviour:
   pathManager: {fileID: 493147367}
   waves:
   - enemySets:
-    - prefab: {fileID: 8024118360108171867, guid: 3daa2438034177a4faf491b40c9140bc, type: 3}
+    - prefab: {fileID: 6960203552290677624, guid: b9be92a761b18dc4da18e8e59bbc7646, type: 3}
       count: 3
     enemiesLeft: 0
   - enemySets:
@@ -6299,6 +6299,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 5270120093065792779, guid: e0be836d2a3cae84798cef02b15a034c, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 5365160862154021750, guid: e0be836d2a3cae84798cef02b15a034c, type: 3}
       propertyPath: m_Name
       value: Towers

--- a/Assets/Scenes/blueprint/Towers.prefab
+++ b/Assets/Scenes/blueprint/Towers.prefab
@@ -1,5 +1,89 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &5270120093065792779
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4939631617451701853}
+  - component: {fileID: 4025806495180109768}
+  m_Layer: 0
+  m_Name: Range Indicator
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4939631617451701853
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5270120093065792779}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: 5, y: 0.1, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8498319615683516689}
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
+--- !u!212 &4025806495180109768
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5270120093065792779}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: -2413806693520163455, guid: a86470a33a6bf42c4b3595704624658b, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.14901961}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
 --- !u!1 &5365160862154021750
 GameObject:
   m_ObjectHideFlags: 0
@@ -30,7 +114,8 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 4939631617451701853}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &8475286871817092655

--- a/Assets/Scripts/In-game Menus/Runes.cs
+++ b/Assets/Scripts/In-game Menus/Runes.cs
@@ -27,7 +27,7 @@ public class Runes : MonoBehaviour {
     private static int firePath2Rune2 = 120;
     private static int firePath2Rune3 = 200;
 
-    private static int earthPath1Rune1 = 80;
+    private static int earthPath1Rune1 = 10;
     private static int earthPath1Rune2 = 120;
     private static int earthPath1Rune3 = 200;
     private static int earthPath2Rune1 = 80;
@@ -133,6 +133,8 @@ public class Runes : MonoBehaviour {
                     if (Fortress.mana >= earthPath1Rune1) {
                         towerScript.range *= 0.75f;
                         towerScript.damage *= 1.25f;
+
+                        Controller.UpdateRangeIndicator();
                         Fortress.mana -= earthPath1Rune1;
                         Controller.UpdateSellValue(earthPath1Rune1);
                         return true;
@@ -142,6 +144,7 @@ public class Runes : MonoBehaviour {
                     if (Fortress.mana >= earthPath1Rune2) {
                         towerScript.fireRate -= 0.15f;
                         towerScript.stunDuration *= 1.25f;
+
                         Fortress.mana -= earthPath1Rune2;
                         Controller.UpdateSellValue(earthPath1Rune2);
                         return true;
@@ -151,6 +154,7 @@ public class Runes : MonoBehaviour {
                     if (Fortress.mana >= earthPath1Rune3) {
                         towerScript.damage *= 1.5f;
                         towerScript.stunDuration *= 1.5f;
+
                         Fortress.mana -= earthPath1Rune3;
                         Controller.UpdateSellValue(earthPath1Rune3);
                         return true;
@@ -165,6 +169,7 @@ public class Runes : MonoBehaviour {
                     if (Fortress.mana >= earthPath2Rune1) {
                         towerScript.stunDuration *= 0.5f;
                         towerScript.damage *= 1.25f;
+
                         Fortress.mana -= earthPath2Rune1;
                         Controller.UpdateSellValue(earthPath2Rune1);
                         return true;
@@ -174,6 +179,8 @@ public class Runes : MonoBehaviour {
                     if (Fortress.mana >= earthPath2Rune2) {
                         towerScript.range *= 1.25f;
                         towerScript.stunDuration = 0.0f;
+
+                        Controller.UpdateRangeIndicator();
                         Fortress.mana -= earthPath2Rune2;
                         Controller.UpdateSellValue(earthPath2Rune2);
                         return true;
@@ -183,6 +190,7 @@ public class Runes : MonoBehaviour {
                     if (Fortress.mana >= earthPath2Rune3) {
                         towerScript.damage *= 1.5f;
                         towerScript.fireRate += 0.3f;
+
                         Fortress.mana -= earthPath2Rune3;
                         Controller.UpdateSellValue(earthPath2Rune3);
                         return true;
@@ -201,6 +209,7 @@ public class Runes : MonoBehaviour {
                     if (Fortress.mana >= firePath1Rune1) {
                         towerScript.fireRate -= 0.2f;
                         towerScript.damage *= 1.25f;
+
                         Fortress.mana -= firePath1Rune1;
                         Controller.UpdateSellValue(firePath1Rune1);
                         return true;
@@ -210,6 +219,8 @@ public class Runes : MonoBehaviour {
                     if (Fortress.mana >= firePath1Rune2) {
                         towerScript.range *= 0.7f;
                         towerScript.burnDamage *= 1.25f;
+
+                        Controller.UpdateRangeIndicator();
                         Fortress.mana -= firePath1Rune2;
                         Controller.UpdateSellValue(firePath1Rune2);
                         return true;
@@ -219,6 +230,7 @@ public class Runes : MonoBehaviour {
                     if (Fortress.mana >= firePath1Rune3) {
                         towerScript.burnDamage *= 1.5f;
                         towerScript.burnDuration *= 2.0f;
+
                         Fortress.mana -= firePath1Rune3;
                         Controller.UpdateSellValue(firePath1Rune3);
                         return true;
@@ -233,6 +245,7 @@ public class Runes : MonoBehaviour {
                     if (Fortress.mana >= firePath2Rune1) {
                         towerScript.damage *= 1.25f;
                         towerScript.burnDamage *= 0.4f;
+
                         Fortress.mana -= firePath2Rune1;
                         Controller.UpdateSellValue(firePath2Rune1);
                         return true;
@@ -242,6 +255,8 @@ public class Runes : MonoBehaviour {
                     if (Fortress.mana >= firePath2Rune2) {
                         towerScript.burnDamage *= 0f;
                         towerScript.range *= 1.25f;
+
+                        Controller.UpdateRangeIndicator();
                         Fortress.mana -= firePath2Rune2;
                         Controller.UpdateSellValue(firePath2Rune2);
                         return true;
@@ -251,6 +266,7 @@ public class Runes : MonoBehaviour {
                     if (Fortress.mana >= firePath2Rune3) {
                         towerScript.fireRate += 0.4f;
                         towerScript.damage *= 1.25f;
+
                         Fortress.mana -= firePath2Rune3;
                         Controller.UpdateSellValue(firePath2Rune3);
                         return true;
@@ -269,6 +285,8 @@ public class Runes : MonoBehaviour {
                     if (Fortress.mana >= windPath1Rune1) {
                         towerScript.range *= 1.25f;
                         towerScript.fireRate -= 0.2f;
+
+                        Controller.UpdateRangeIndicator();
                         Fortress.mana -= windPath1Rune1;
                         Controller.UpdateSellValue(windPath1Rune1);
                         return true;
@@ -278,6 +296,7 @@ public class Runes : MonoBehaviour {
                     if (Fortress.mana >= windPath1Rune2) {
                         towerScript.critChance *= 2.5f;
                         towerScript.fireRate -= 0.2f;
+
                         Fortress.mana -= windPath1Rune2;
                         Controller.UpdateSellValue(windPath1Rune2);
                         return true;
@@ -287,6 +306,7 @@ public class Runes : MonoBehaviour {
                     if (Fortress.mana >= windPath1Rune3) {
                         towerScript.critDamage *= 1.75f;
                         towerScript.damage *= 1.5f;
+
                         Fortress.mana -= windPath1Rune3;
                         Controller.UpdateSellValue(windPath1Rune3);
                         return true;
@@ -301,6 +321,7 @@ public class Runes : MonoBehaviour {
                     if (Fortress.mana >= windPath2Rune1) {
                         towerScript.critChance *= 0.5f;
                         towerScript.damage *= 1.5f;
+
                         Fortress.mana -= windPath2Rune1;
                         Controller.UpdateSellValue(windPath2Rune1);
                         return true;
@@ -310,6 +331,7 @@ public class Runes : MonoBehaviour {
                     if (Fortress.mana >= windPath2Rune2) {
                         towerScript.critChance *= 0f;
                         towerScript.fireRate += 0.3f;
+
                         Fortress.mana -= windPath2Rune2;
                         Controller.UpdateSellValue(windPath2Rune2);
                         return true;
@@ -319,6 +341,8 @@ public class Runes : MonoBehaviour {
                     if (Fortress.mana >= windPath2Rune3) {
                         towerScript.fireRate += 0.45f;
                         towerScript.range *= 1.5f;
+
+                        Controller.UpdateRangeIndicator();
                         Fortress.mana -= windPath2Rune3;
                         Controller.UpdateSellValue(windPath2Rune3);
                         return true;
@@ -337,6 +361,7 @@ public class Runes : MonoBehaviour {
                     if (Fortress.mana >= waterPath1Rune1) {
                         towerScript.splashRadius *= 1.25f;
                         towerScript.fireRate -= 0.25f;
+
                         Fortress.mana -= waterPath1Rune1;
                         Controller.UpdateSellValue(waterPath1Rune1);
                         return true;
@@ -346,6 +371,8 @@ public class Runes : MonoBehaviour {
                     if (Fortress.mana >= waterPath1Rune2) {
                         towerScript.damage *= 1.25f;
                         towerScript.range *= 0.75f;
+
+                        Controller.UpdateRangeIndicator();
                         Fortress.mana -= waterPath1Rune2;
                         Controller.UpdateSellValue(waterPath1Rune2);
                         return true;
@@ -356,6 +383,7 @@ public class Runes : MonoBehaviour {
                     if (Fortress.mana >= waterPath1Rune3) {
                         towerScript.splashRadius *= 1.35f;
                         towerScript.damage *= 1.5f;
+
                         Fortress.mana -= waterPath1Rune3;
                         Controller.UpdateSellValue(waterPath1Rune3);
                         return true;
@@ -370,6 +398,8 @@ public class Runes : MonoBehaviour {
                     if (Fortress.mana >= waterPath2Rune1) {
                         towerScript.splashRadius *= 0.7f;
                         towerScript.range *= 1.25f;
+
+                        Controller.UpdateRangeIndicator();
                         Fortress.mana -= waterPath2Rune1;
                         Controller.UpdateSellValue(waterPath2Rune1);
                         return true;
@@ -379,6 +409,7 @@ public class Runes : MonoBehaviour {
                     if (Fortress.mana >= waterPath2Rune2) {
                         towerScript.splashRadius *= 0f;
                         towerScript.damage *= 1.3f;
+
                         Fortress.mana -= waterPath2Rune2;
                         Controller.UpdateSellValue(waterPath2Rune2);
                         return true;
@@ -388,6 +419,8 @@ public class Runes : MonoBehaviour {
                     if (Fortress.mana >= waterPath2Rune3) {
                         towerScript.range *= 1.35f;
                         towerScript.damage *= 1.5f;
+
+                        Controller.UpdateRangeIndicator();
                         Fortress.mana -= waterPath2Rune3;
                         Controller.UpdateSellValue(waterPath2Rune3);
                         return true;

--- a/Assets/Scripts/In-game Menus/Store.cs
+++ b/Assets/Scripts/In-game Menus/Store.cs
@@ -6,8 +6,6 @@ using UnityEngine.UI;
 
 public class Store : MonoBehaviour {
 
-    private Vector3 offsetVector = new Vector3(0, 5, 0);
-
     public void PurchaseTower() {
 
         // referencing the script to access the tower cost in the if statement
@@ -29,7 +27,7 @@ public class Store : MonoBehaviour {
             // placing the tower
             Instantiate(
                 towerSelected,
-                Controller.currentTile.transform.position + offsetVector,
+                Controller.currentTile.transform.position,
                 Quaternion.identity,
                 GameObject.Find("Towers").transform
             );

--- a/Assets/Scripts/Input/Controller.cs
+++ b/Assets/Scripts/Input/Controller.cs
@@ -25,6 +25,7 @@ public class Controller : MonoBehaviour {
     private static Transform rankParent;
     private static Transform towerMenuParent;
     private static Transform runicTabletsParent;
+    private static Transform towersParent;
 
     // tile and store
     private static Material selectedTileMaterial;
@@ -35,6 +36,7 @@ public class Controller : MonoBehaviour {
     // tower menu
     private bool mouseOverUI;
     private static GameObject tablet;
+    private static GameObject rangeIndicator;
     public static GameObject towerMenu;
     public static GameObject currentTower;
     public static GameObject earthRunicTablet;
@@ -87,6 +89,10 @@ public class Controller : MonoBehaviour {
         windRunicTablet = runicTabletsParent.Find("Wind Runic Tablet").gameObject;
         waterRunicTablet = runicTabletsParent.Find("Water Runic Tablet").gameObject;
 
+        // obtaining reference to the range indicator disk
+        towersParent = GameObject.Find("Towers").transform;
+        rangeIndicator = towersParent.Find("Range Indicator").gameObject;
+
         keybindings = new Keybindings();
         mainCamera = Camera.main;
     }
@@ -118,6 +124,24 @@ public class Controller : MonoBehaviour {
     }
 
     //---------------------------------------------------------//
+
+    private static void ToggleRangeIndicator() {
+        if (rangeIndicator.activeInHierarchy) {
+            rangeIndicator.SetActive(false);
+            return;
+        }
+
+        Tower towerScript = currentTower.GetComponent<Tower>();
+        rangeIndicator.transform.localScale = new Vector3(2 * towerScript.range, 2 * towerScript.range, 2 * towerScript.range);
+        rangeIndicator.transform.position = currentTower.transform.position + new Vector3(0f, 0.01f, 0f);
+        rangeIndicator.SetActive(true);
+    }
+
+    // for updating the range indicator while it's active, e.g. when purchasing a range tower rune
+    public static void UpdateRangeIndicator() {
+        Tower towerScript = currentTower.GetComponent<Tower>();
+        rangeIndicator.transform.localScale = new Vector3(2 * towerScript.range, 2 * towerScript.range, 2 * towerScript.range);
+    }
 
     public static void UpdateSellValue(int value) {
         Tower towerScript = currentTower.GetComponent<Tower>();
@@ -215,6 +239,7 @@ public class Controller : MonoBehaviour {
     public static void CloseTowerMenu() {
         currentTower = null;
         towerMenu.SetActive(false);
+        rangeIndicator.SetActive(false);
     }
 
     private void OpenTowerMenu() {
@@ -232,6 +257,7 @@ public class Controller : MonoBehaviour {
             currentTower = objectClicked;
             towerMenu.SetActive(true);
             FillTowerMenu();
+            ToggleRangeIndicator();
             ToggleRunicTablet();
         }
         // a tower is selected already
@@ -241,11 +267,16 @@ public class Controller : MonoBehaviour {
                 ToggleRunicTablet();
                 CloseTowerMenu();
             }
-            // if it's a different tower, reload the menu with its information
+            // if it's a different tower, reload it
             else {
+                // unload the currently selected tower
                 ToggleRunicTablet();
+                ToggleRangeIndicator();
+
+                // move to the other tower and load it
                 currentTower = objectClicked;
                 ToggleRunicTablet();
+                ToggleRangeIndicator();
                 FillTowerMenu();
             }
         }

--- a/Assets/Scripts/Towers/Tower.cs
+++ b/Assets/Scripts/Towers/Tower.cs
@@ -160,10 +160,6 @@ public class Tower : MonoBehaviour {
     // Start is called before the first frame update
     void Start() {
         projectileBin = GameObject.FindWithTag("EntityBin");
-        //temporary way to change firing mode
-        //----------------------------------------------------------------------------
-        //Debug.Log("Selected Firing Mode: " + Modes);
-        //----------------------------------------------------------------------------
         InvokeRepeating("UpdateTarget", 0f, 0.5f);
     }
 


### PR DESCRIPTION
Clicking on a tower (i.e. opening the tower menu) now shows a gray-white circle indicating the tower's range.

If a tower rune is bought and it alters range, the circle updates to reflect this.

Adjusted tower prefabs so that the range is calculated from the floor, and the towers now also sit on top of the pedestals.