### PR TITLE
New fortress object & fix sound overlap

### DIFF
--- a/Assets/Scenes/Level 1.unity
+++ b/Assets/Scenes/Level 1.unity
@@ -226,6 +226,75 @@ Transform:
   m_Children: []
   m_Father: {fileID: 750283516}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &8656284
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 767287292}
+    m_Modifications:
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 86.7
+      objectReference: {fileID: 0}
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.33
+      objectReference: {fileID: 0}
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -25
+      objectReference: {fileID: 0}
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6013428094979532239, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: waveCount
+      value: 
+      objectReference: {fileID: 1333879970}
+    - target: {fileID: 6013428094979532239, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: manaAmount
+      value: 
+      objectReference: {fileID: 2001910255}
+    - target: {fileID: 6013428094979532239, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: healthAmount
+      value: 
+      objectReference: {fileID: 2102148627}
+    - target: {fileID: 8321232959546192366, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_Name
+      value: Fortress
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
 --- !u!1001 &34349473
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1657,7 +1726,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 1966064429}
+  - {fileID: 1688065599}
   - {fileID: 671364545}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1935,17 +2004,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 5681961582486627888, guid: a3ac3f03c0f69254fa011208c7e0dfcc, type: 3}
   m_PrefabInstance: {fileID: 792176888}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &852172106 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 7295224555717100950, guid: 0e582ce9e556ac84ba3c2483e930cf18, type: 3}
-  m_PrefabInstance: {fileID: 4301559497734545173}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &907052015
 GameObject:
   m_ObjectHideFlags: 0
@@ -3247,6 +3305,17 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 5681961582486627888, guid: a3ac3f03c0f69254fa011208c7e0dfcc, type: 3}
   m_PrefabInstance: {fileID: 1329169528}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1333879970 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4767395814852217904, guid: 0e582ce9e556ac84ba3c2483e930cf18, type: 3}
+  m_PrefabInstance: {fileID: 4301559497734545173}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1343913680
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3371,17 +3440,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 5681961582486627888, guid: a3ac3f03c0f69254fa011208c7e0dfcc, type: 3}
   m_PrefabInstance: {fileID: 1367189888}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1381878830 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 3271285978118841649, guid: 0e582ce9e556ac84ba3c2483e930cf18, type: 3}
-  m_PrefabInstance: {fileID: 4301559497734545173}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &1399357899
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4068,6 +4126,11 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 5681961582486627888, guid: a3ac3f03c0f69254fa011208c7e0dfcc, type: 3}
   m_PrefabInstance: {fileID: 1644859040}
   m_PrefabAsset: {fileID: 0}
+--- !u!4 &1688065599 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+  m_PrefabInstance: {fileID: 8656284}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1697646891
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4130,17 +4193,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 5681961582486627888, guid: a3ac3f03c0f69254fa011208c7e0dfcc, type: 3}
   m_PrefabInstance: {fileID: 1697646891}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1744263300 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 4767395814852217904, guid: 0e582ce9e556ac84ba3c2483e930cf18, type: 3}
-  m_PrefabInstance: {fileID: 4301559497734545173}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &1744612050
 GameObject:
   m_ObjectHideFlags: 0
@@ -4802,11 +4854,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 5681961582486627888, guid: a3ac3f03c0f69254fa011208c7e0dfcc, type: 3}
   m_PrefabInstance: {fileID: 1949284612}
   m_PrefabAsset: {fileID: 0}
---- !u!4 &1966064429 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4798737520360345639, guid: 88a6059a6f68cad419274fb9e8ce4c68, type: 3}
-  m_PrefabInstance: {fileID: 171549609918309832}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1967117999
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4869,6 +4916,17 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 5681961582486627888, guid: a3ac3f03c0f69254fa011208c7e0dfcc, type: 3}
   m_PrefabInstance: {fileID: 1967117999}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &2001910255 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7295224555717100950, guid: 0e582ce9e556ac84ba3c2483e930cf18, type: 3}
+  m_PrefabInstance: {fileID: 4301559497734545173}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &2028917416
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -5117,6 +5175,17 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 5681961582486627888, guid: a3ac3f03c0f69254fa011208c7e0dfcc, type: 3}
   m_PrefabInstance: {fileID: 2076844268}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &2102148627 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3271285978118841649, guid: 0e582ce9e556ac84ba3c2483e930cf18, type: 3}
+  m_PrefabInstance: {fileID: 4301559497734545173}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &2138589018
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -5298,75 +5367,6 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: e70bdd9b9c922764790bd3daf52c558d, type: 3}
---- !u!1001 &171549609918309832
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 767287292}
-    m_Modifications:
-    - target: {fileID: 4798737520360345639, guid: 88a6059a6f68cad419274fb9e8ce4c68, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 85
-      objectReference: {fileID: 0}
-    - target: {fileID: 4798737520360345639, guid: 88a6059a6f68cad419274fb9e8ce4c68, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 4798737520360345639, guid: 88a6059a6f68cad419274fb9e8ce4c68, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -25
-      objectReference: {fileID: 0}
-    - target: {fileID: 4798737520360345639, guid: 88a6059a6f68cad419274fb9e8ce4c68, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4798737520360345639, guid: 88a6059a6f68cad419274fb9e8ce4c68, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4798737520360345639, guid: 88a6059a6f68cad419274fb9e8ce4c68, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4798737520360345639, guid: 88a6059a6f68cad419274fb9e8ce4c68, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4798737520360345639, guid: 88a6059a6f68cad419274fb9e8ce4c68, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4798737520360345639, guid: 88a6059a6f68cad419274fb9e8ce4c68, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4798737520360345639, guid: 88a6059a6f68cad419274fb9e8ce4c68, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7651750887845240465, guid: 88a6059a6f68cad419274fb9e8ce4c68, type: 3}
-      propertyPath: m_Name
-      value: Fortress
-      objectReference: {fileID: 0}
-    - target: {fileID: 8316045476602756543, guid: 88a6059a6f68cad419274fb9e8ce4c68, type: 3}
-      propertyPath: waveCount
-      value: 
-      objectReference: {fileID: 1744263300}
-    - target: {fileID: 8316045476602756543, guid: 88a6059a6f68cad419274fb9e8ce4c68, type: 3}
-      propertyPath: manaAmount
-      value: 
-      objectReference: {fileID: 852172106}
-    - target: {fileID: 8316045476602756543, guid: 88a6059a6f68cad419274fb9e8ce4c68, type: 3}
-      propertyPath: healthAmount
-      value: 
-      objectReference: {fileID: 1381878830}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 88a6059a6f68cad419274fb9e8ce4c68, type: 3}
 --- !u!1001 &427132690273082154
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Level 2.unity
+++ b/Assets/Scenes/Level 2.unity
@@ -2547,7 +2547,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 1966064429}
+  - {fileID: 1546021561}
   - {fileID: 671364545}
   - {fileID: 368117553}
   m_Father: {fileID: 0}
@@ -4442,17 +4442,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 5681961582486627888, guid: a3ac3f03c0f69254fa011208c7e0dfcc, type: 3}
   m_PrefabInstance: {fileID: 1362277556}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1381878830 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 3271285978118841649, guid: 0e582ce9e556ac84ba3c2483e930cf18, type: 3}
-  m_PrefabInstance: {fileID: 4301559497734545173}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &1409469699
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -5136,6 +5125,80 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a3ac3f03c0f69254fa011208c7e0dfcc, type: 3}
+--- !u!1001 &1546021560
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 767287292}
+    m_Modifications:
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 75
+      objectReference: {fileID: 0}
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -35
+      objectReference: {fileID: 0}
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6013428094979532239, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: waveCount
+      value: 
+      objectReference: {fileID: 4301559497734545174}
+    - target: {fileID: 6013428094979532239, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: manaAmount
+      value: 
+      objectReference: {fileID: 4301559497734545176}
+    - target: {fileID: 6013428094979532239, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: healthAmount
+      value: 
+      objectReference: {fileID: 4301559497734545175}
+    - target: {fileID: 8321232959546192366, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_Name
+      value: Fortress
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+--- !u!4 &1546021561 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+  m_PrefabInstance: {fileID: 1546021560}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1603203972
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -5531,17 +5594,6 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a3ac3f03c0f69254fa011208c7e0dfcc, type: 3}
---- !u!114 &1744263300 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 4767395814852217904, guid: 0e582ce9e556ac84ba3c2483e930cf18, type: 3}
-  m_PrefabInstance: {fileID: 4301559497734545173}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &1744612050
 GameObject:
   m_ObjectHideFlags: 0
@@ -6535,127 +6587,6 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a3ac3f03c0f69254fa011208c7e0dfcc, type: 3}
---- !u!1 &1966064425
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1966064429}
-  - component: {fileID: 1966064428}
-  - component: {fileID: 1966064427}
-  - component: {fileID: 1966064430}
-  - component: {fileID: 1966064426}
-  m_Layer: 0
-  m_Name: Fortress
-  m_TagString: Fortress
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!65 &1966064426
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1966064425}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 1, y: 1, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
---- !u!23 &1966064427
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1966064425}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!33 &1966064428
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1966064425}
-  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!4 &1966064429
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1966064425}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 75, y: 5, z: -35}
-  m_LocalScale: {x: 10, y: 10, z: 20}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 767287292}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1966064430
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1966064425}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8966e863e2a1493449667462a5f42cfa, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  manaAmount: {fileID: 0}
-  healthAmount: {fileID: 1381878830}
-  waveCount: {fileID: 1744263300}
 --- !u!1001 &1977701797
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -7647,6 +7578,39 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 0e582ce9e556ac84ba3c2483e930cf18, type: 3}
+--- !u!114 &4301559497734545174 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4767395814852217904, guid: 0e582ce9e556ac84ba3c2483e930cf18, type: 3}
+  m_PrefabInstance: {fileID: 4301559497734545173}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &4301559497734545175 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3271285978118841649, guid: 0e582ce9e556ac84ba3c2483e930cf18, type: 3}
+  m_PrefabInstance: {fileID: 4301559497734545173}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &4301559497734545176 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7295224555717100950, guid: 0e582ce9e556ac84ba3c2483e930cf18, type: 3}
+  m_PrefabInstance: {fileID: 4301559497734545173}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &4499579649663763133
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Level 3.unity
+++ b/Assets/Scenes/Level 3.unity
@@ -2539,7 +2539,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 1966064429}
+  - {fileID: 1597760332}
   - {fileID: 671364545}
   - {fileID: 368117553}
   - {fileID: 814651887}
@@ -4311,17 +4311,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 5681961582486627888, guid: a3ac3f03c0f69254fa011208c7e0dfcc, type: 3}
   m_PrefabInstance: {fileID: 1937785774}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1381878830 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 3271285978118841649, guid: 0e582ce9e556ac84ba3c2483e930cf18, type: 3}
-  m_PrefabInstance: {fileID: 4301559497734545173}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &1387977692
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4702,6 +4691,80 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a3ac3f03c0f69254fa011208c7e0dfcc, type: 3}
+--- !u!1001 &1597760331
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 767287292}
+    m_Modifications:
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 85
+      objectReference: {fileID: 0}
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6013428094979532239, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: waveCount
+      value: 
+      objectReference: {fileID: 4301559497734545174}
+    - target: {fileID: 6013428094979532239, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: manaAmount
+      value: 
+      objectReference: {fileID: 4301559497734545176}
+    - target: {fileID: 6013428094979532239, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: healthAmount
+      value: 
+      objectReference: {fileID: 4301559497734545175}
+    - target: {fileID: 8321232959546192366, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_Name
+      value: Fortress
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+--- !u!4 &1597760332 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+  m_PrefabInstance: {fileID: 1597760331}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &1597985308 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 5681961582486627888, guid: a3ac3f03c0f69254fa011208c7e0dfcc, type: 3}
@@ -4951,17 +5014,6 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a3ac3f03c0f69254fa011208c7e0dfcc, type: 3}
---- !u!114 &1744263300 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 4767395814852217904, guid: 0e582ce9e556ac84ba3c2483e930cf18, type: 3}
-  m_PrefabInstance: {fileID: 4301559497734545173}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &1744612050
 GameObject:
   m_ObjectHideFlags: 0
@@ -5860,127 +5912,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 5681961582486627888, guid: a3ac3f03c0f69254fa011208c7e0dfcc, type: 3}
   m_PrefabInstance: {fileID: 128682649}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &1966064425
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1966064429}
-  - component: {fileID: 1966064428}
-  - component: {fileID: 1966064427}
-  - component: {fileID: 1966064430}
-  - component: {fileID: 1966064426}
-  m_Layer: 0
-  m_Name: Fortress
-  m_TagString: Fortress
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!65 &1966064426
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1966064425}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 1, y: 1, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
---- !u!23 &1966064427
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1966064425}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!33 &1966064428
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1966064425}
-  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!4 &1966064429
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1966064425}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 85, y: 5, z: 5}
-  m_LocalScale: {x: 10, y: 10, z: 20}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 767287292}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1966064430
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1966064425}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8966e863e2a1493449667462a5f42cfa, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  manaAmount: {fileID: 0}
-  healthAmount: {fileID: 1381878830}
-  waveCount: {fileID: 1744263300}
 --- !u!1001 &1969856569
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -7236,6 +7167,39 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 0e582ce9e556ac84ba3c2483e930cf18, type: 3}
+--- !u!114 &4301559497734545174 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4767395814852217904, guid: 0e582ce9e556ac84ba3c2483e930cf18, type: 3}
+  m_PrefabInstance: {fileID: 4301559497734545173}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &4301559497734545175 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3271285978118841649, guid: 0e582ce9e556ac84ba3c2483e930cf18, type: 3}
+  m_PrefabInstance: {fileID: 4301559497734545173}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &4301559497734545176 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7295224555717100950, guid: 0e582ce9e556ac84ba3c2483e930cf18, type: 3}
+  m_PrefabInstance: {fileID: 4301559497734545173}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &4609851964573390921
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Level 4.unity
+++ b/Assets/Scenes/Level 4.unity
@@ -1205,7 +1205,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 1966064429}
+  - {fileID: 1791754076}
   - {fileID: 671364545}
   - {fileID: 814651887}
   m_Father: {fileID: 0}
@@ -2188,17 +2188,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 999215808}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1381878830 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 3271285978118841649, guid: 0e582ce9e556ac84ba3c2483e930cf18, type: 3}
-  m_PrefabInstance: {fileID: 4301559497734545173}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &1451405122
 GameObject:
   m_ObjectHideFlags: 0
@@ -2338,17 +2327,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &1744263300 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 4767395814852217904, guid: 0e582ce9e556ac84ba3c2483e930cf18, type: 3}
-  m_PrefabInstance: {fileID: 4301559497734545173}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &1777206069 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 2185627727751243311, guid: 0e582ce9e556ac84ba3c2483e930cf18, type: 3}
@@ -2360,6 +2338,80 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1001 &1791754075
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 767287292}
+    m_Modifications:
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 85
+      objectReference: {fileID: 0}
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6013428094979532239, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: waveCount
+      value: 
+      objectReference: {fileID: 4301559497734545174}
+    - target: {fileID: 6013428094979532239, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: manaAmount
+      value: 
+      objectReference: {fileID: 4301559497734545176}
+    - target: {fileID: 6013428094979532239, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: healthAmount
+      value: 
+      objectReference: {fileID: 4301559497734545175}
+    - target: {fileID: 8321232959546192366, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_Name
+      value: Fortress
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+--- !u!4 &1791754076 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+  m_PrefabInstance: {fileID: 1791754075}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1843418702
 GameObject:
   m_ObjectHideFlags: 0
@@ -2603,127 +2655,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 523348250}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1966064425
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1966064429}
-  - component: {fileID: 1966064428}
-  - component: {fileID: 1966064427}
-  - component: {fileID: 1966064430}
-  - component: {fileID: 1966064426}
-  m_Layer: 0
-  m_Name: Fortress
-  m_TagString: Fortress
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!65 &1966064426
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1966064425}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 1, y: 1, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
---- !u!23 &1966064427
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1966064425}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!33 &1966064428
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1966064425}
-  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!4 &1966064429
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1966064425}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 85, y: 5, z: 5}
-  m_LocalScale: {x: 10, y: 10, z: 20}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 767287292}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1966064430
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1966064425}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8966e863e2a1493449667462a5f42cfa, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  manaAmount: {fileID: 0}
-  healthAmount: {fileID: 1381878830}
-  waveCount: {fileID: 1744263300}
 --- !u!1001 &50569074296779946
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3215,6 +3146,39 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 0e582ce9e556ac84ba3c2483e930cf18, type: 3}
+--- !u!114 &4301559497734545174 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4767395814852217904, guid: 0e582ce9e556ac84ba3c2483e930cf18, type: 3}
+  m_PrefabInstance: {fileID: 4301559497734545173}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &4301559497734545175 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3271285978118841649, guid: 0e582ce9e556ac84ba3c2483e930cf18, type: 3}
+  m_PrefabInstance: {fileID: 4301559497734545173}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &4301559497734545176 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7295224555717100950, guid: 0e582ce9e556ac84ba3c2483e930cf18, type: 3}
+  m_PrefabInstance: {fileID: 4301559497734545173}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &5390728159137711625
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Level 5.unity
+++ b/Assets/Scenes/Level 5.unity
@@ -340,6 +340,80 @@ Transform:
   m_Children: []
   m_Father: {fileID: 750283516}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &24080239
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 767287292}
+    m_Modifications:
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 85
+      objectReference: {fileID: 0}
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6013428094979532239, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: waveCount
+      value: 
+      objectReference: {fileID: 4301559497734545174}
+    - target: {fileID: 6013428094979532239, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: manaAmount
+      value: 
+      objectReference: {fileID: 4301559497734545176}
+    - target: {fileID: 6013428094979532239, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: healthAmount
+      value: 
+      objectReference: {fileID: 4301559497734545175}
+    - target: {fileID: 8321232959546192366, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_Name
+      value: Fortress
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+--- !u!4 &24080240 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+  m_PrefabInstance: {fileID: 24080239}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &46198694
 GameObject:
   m_ObjectHideFlags: 0
@@ -2267,7 +2341,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 1966064429}
+  - {fileID: 24080240}
   - {fileID: 671364545}
   - {fileID: 368117553}
   - {fileID: 814651887}
@@ -3750,17 +3824,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 5681961582486627888, guid: a3ac3f03c0f69254fa011208c7e0dfcc, type: 3}
   m_PrefabInstance: {fileID: 709874028}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1381878830 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 3271285978118841649, guid: 0e582ce9e556ac84ba3c2483e930cf18, type: 3}
-  m_PrefabInstance: {fileID: 4301559497734545173}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!4 &1410054910 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 5681961582486627888, guid: a3ac3f03c0f69254fa011208c7e0dfcc, type: 3}
@@ -4373,17 +4436,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 5681961582486627888, guid: a3ac3f03c0f69254fa011208c7e0dfcc, type: 3}
   m_PrefabInstance: {fileID: 1708999902}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1744263300 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 4767395814852217904, guid: 0e582ce9e556ac84ba3c2483e930cf18, type: 3}
-  m_PrefabInstance: {fileID: 4301559497734545173}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &1744612050
 GameObject:
   m_ObjectHideFlags: 0
@@ -5145,127 +5197,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 523348250}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1966064425
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1966064429}
-  - component: {fileID: 1966064428}
-  - component: {fileID: 1966064427}
-  - component: {fileID: 1966064430}
-  - component: {fileID: 1966064426}
-  m_Layer: 0
-  m_Name: Fortress
-  m_TagString: Fortress
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!65 &1966064426
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1966064425}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 1, y: 1, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
---- !u!23 &1966064427
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1966064425}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!33 &1966064428
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1966064425}
-  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!4 &1966064429
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1966064425}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 85, y: 5, z: 5}
-  m_LocalScale: {x: 10, y: 10, z: 20}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 767287292}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1966064430
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1966064425}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8966e863e2a1493449667462a5f42cfa, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  manaAmount: {fileID: 0}
-  healthAmount: {fileID: 1381878830}
-  waveCount: {fileID: 1744263300}
 --- !u!1001 &1970068215
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -6119,6 +6050,39 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 0e582ce9e556ac84ba3c2483e930cf18, type: 3}
+--- !u!114 &4301559497734545174 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4767395814852217904, guid: 0e582ce9e556ac84ba3c2483e930cf18, type: 3}
+  m_PrefabInstance: {fileID: 4301559497734545173}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &4301559497734545175 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3271285978118841649, guid: 0e582ce9e556ac84ba3c2483e930cf18, type: 3}
+  m_PrefabInstance: {fileID: 4301559497734545173}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &4301559497734545176 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7295224555717100950, guid: 0e582ce9e556ac84ba3c2483e930cf18, type: 3}
+  m_PrefabInstance: {fileID: 4301559497734545173}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &5619314388147776404
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Level 6.unity
+++ b/Assets/Scenes/Level 6.unity
@@ -1932,6 +1932,80 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 5681961582486627888, guid: a3ac3f03c0f69254fa011208c7e0dfcc, type: 3}
   m_PrefabInstance: {fileID: 1079291360}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &749157592
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 767287292}
+    m_Modifications:
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 85
+      objectReference: {fileID: 0}
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6013428094979532239, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: waveCount
+      value: 
+      objectReference: {fileID: 4301559497734545174}
+    - target: {fileID: 6013428094979532239, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: manaAmount
+      value: 
+      objectReference: {fileID: 4301559497734545176}
+    - target: {fileID: 6013428094979532239, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: healthAmount
+      value: 
+      objectReference: {fileID: 4301559497734545175}
+    - target: {fileID: 8321232959546192366, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+      propertyPath: m_Name
+      value: Fortress
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+--- !u!4 &749157593 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5349289423251884298, guid: f645d9ee0c1f544489d6e426ca996c5b, type: 3}
+  m_PrefabInstance: {fileID: 749157592}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &750283515
 GameObject:
   m_ObjectHideFlags: 0
@@ -2005,7 +2079,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 1966064429}
+  - {fileID: 749157593}
   - {fileID: 671364545}
   - {fileID: 368117553}
   - {fileID: 814651887}
@@ -3557,17 +3631,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 5681961582486627888, guid: a3ac3f03c0f69254fa011208c7e0dfcc, type: 3}
   m_PrefabInstance: {fileID: 1381792272}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1381878830 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 3271285978118841649, guid: 0e582ce9e556ac84ba3c2483e930cf18, type: 3}
-  m_PrefabInstance: {fileID: 4301559497734545173}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!4 &1384499716 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 5681961582486627888, guid: a3ac3f03c0f69254fa011208c7e0dfcc, type: 3}
@@ -3885,17 +3948,6 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a3ac3f03c0f69254fa011208c7e0dfcc, type: 3}
---- !u!114 &1744263300 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 4767395814852217904, guid: 0e582ce9e556ac84ba3c2483e930cf18, type: 3}
-  m_PrefabInstance: {fileID: 4301559497734545173}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &1744612050
 GameObject:
   m_ObjectHideFlags: 0
@@ -4482,127 +4534,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 523348250}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1966064425
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1966064429}
-  - component: {fileID: 1966064428}
-  - component: {fileID: 1966064427}
-  - component: {fileID: 1966064430}
-  - component: {fileID: 1966064426}
-  m_Layer: 0
-  m_Name: Fortress
-  m_TagString: Fortress
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!65 &1966064426
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1966064425}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 1, y: 1, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
---- !u!23 &1966064427
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1966064425}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!33 &1966064428
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1966064425}
-  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!4 &1966064429
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1966064425}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 85, y: 5, z: 5}
-  m_LocalScale: {x: 10, y: 10, z: 20}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 767287292}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1966064430
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1966064425}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8966e863e2a1493449667462a5f42cfa, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  manaAmount: {fileID: 0}
-  healthAmount: {fileID: 1381878830}
-  waveCount: {fileID: 1744263300}
 --- !u!1001 &1976212432
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -17529,6 +17460,39 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 0e582ce9e556ac84ba3c2483e930cf18, type: 3}
+--- !u!114 &4301559497734545174 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4767395814852217904, guid: 0e582ce9e556ac84ba3c2483e930cf18, type: 3}
+  m_PrefabInstance: {fileID: 4301559497734545173}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &4301559497734545175 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3271285978118841649, guid: 0e582ce9e556ac84ba3c2483e930cf18, type: 3}
+  m_PrefabInstance: {fileID: 4301559497734545173}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &4301559497734545176 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7295224555717100950, guid: 0e582ce9e556ac84ba3c2483e930cf18, type: 3}
+  m_PrefabInstance: {fileID: 4301559497734545173}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &4407323410385622569
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/blueprint/Fortress.prefab
+++ b/Assets/Scenes/blueprint/Fortress.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &7651750887845240465
+--- !u!1 &8321232959546192366
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,11 +8,11 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 4798737520360345639}
-  - component: {fileID: 9107544484409530687}
-  - component: {fileID: 8034663686552080946}
-  - component: {fileID: 8316045476602756543}
-  - component: {fileID: 1292381473884347735}
+  - component: {fileID: 5349289423251884298}
+  - component: {fileID: 2727691312551213855}
+  - component: {fileID: 6119843974485080229}
+  - component: {fileID: 6013428094979532239}
+  - component: {fileID: 5709489291141209424}
   m_Layer: 0
   m_Name: Fortress
   m_TagString: Fortress
@@ -20,36 +20,37 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &4798737520360345639
+--- !u!4 &5349289423251884298
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7651750887845240465}
+  m_GameObject: {fileID: 8321232959546192366}
   serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 85, y: 5, z: -25}
-  m_LocalScale: {x: 10, y: 10, z: 20}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 85, y: 0, z: -25}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 4748924775490959321}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!33 &9107544484409530687
+--- !u!33 &2727691312551213855
 MeshFilter:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7651750887845240465}
+  m_GameObject: {fileID: 8321232959546192366}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!23 &8034663686552080946
+--- !u!23 &6119843974485080229
 MeshRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7651750887845240465}
+  m_GameObject: {fileID: 8321232959546192366}
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
@@ -85,13 +86,13 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!114 &8316045476602756543
+--- !u!114 &6013428094979532239
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7651750887845240465}
+  m_GameObject: {fileID: 8321232959546192366}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 8966e863e2a1493449667462a5f42cfa, type: 3}
@@ -100,13 +101,13 @@ MonoBehaviour:
   manaAmount: {fileID: 0}
   healthAmount: {fileID: 0}
   waveCount: {fileID: 0}
---- !u!65 &1292381473884347735
+--- !u!65 &5709489291141209424
 BoxCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7651750887845240465}
+  m_GameObject: {fileID: 8321232959546192366}
   m_Material: {fileID: 0}
   m_IncludeLayers:
     serializedVersion: 2
@@ -119,5 +120,79 @@ BoxCollider:
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3
-  m_Size: {x: 1, y: 1, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
+  m_Size: {x: 10, y: 20, z: 20}
+  m_Center: {x: 0, y: 10, z: 0}
+--- !u!1001 &4748924775491367005
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5349289423251884298}
+    m_Modifications:
+    - target: {fileID: 187918, guid: 77a599bd67f72e24999e1d5d60f433d0, type: 3}
+      propertyPath: m_Name
+      value: Tower Mage
+      objectReference: {fileID: 0}
+    - target: {fileID: 411524, guid: 77a599bd67f72e24999e1d5d60f433d0, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 16
+      objectReference: {fileID: 0}
+    - target: {fileID: 411524, guid: 77a599bd67f72e24999e1d5d60f433d0, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 411524, guid: 77a599bd67f72e24999e1d5d60f433d0, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 16
+      objectReference: {fileID: 0}
+    - target: {fileID: 411524, guid: 77a599bd67f72e24999e1d5d60f433d0, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 411524, guid: 77a599bd67f72e24999e1d5d60f433d0, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 411524, guid: 77a599bd67f72e24999e1d5d60f433d0, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 411524, guid: 77a599bd67f72e24999e1d5d60f433d0, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 411524, guid: 77a599bd67f72e24999e1d5d60f433d0, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 411524, guid: 77a599bd67f72e24999e1d5d60f433d0, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 411524, guid: 77a599bd67f72e24999e1d5d60f433d0, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 411524, guid: 77a599bd67f72e24999e1d5d60f433d0, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 411524, guid: 77a599bd67f72e24999e1d5d60f433d0, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 411524, guid: 77a599bd67f72e24999e1d5d60f433d0, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77a599bd67f72e24999e1d5d60f433d0, type: 3}
+--- !u!4 &4748924775490959321 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 411524, guid: 77a599bd67f72e24999e1d5d60f433d0, type: 3}
+  m_PrefabInstance: {fileID: 4748924775491367005}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/Scenes/blueprint/Fortress.prefab.meta
+++ b/Assets/Scenes/blueprint/Fortress.prefab.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 88a6059a6f68cad419274fb9e8ce4c68
+guid: f645d9ee0c1f544489d6e426ca996c5b
 PrefabImporter:
   externalObjects: {}
   userData: 

--- a/Assets/Scripts/SoundManager.cs
+++ b/Assets/Scripts/SoundManager.cs
@@ -26,6 +26,7 @@ public class SoundManager : MonoBehaviour
     [SerializeField] private AudioClip[] soundList;
     [SerializeField] private int audioSourcePoolSize = 20;
     [SerializeField] private AudioMixer audioMixer;
+    private float MinSoundInterval = 0.1f;
     private static SoundManager instance;
     private List<AudioSource> audioSourcePool;
 
@@ -130,6 +131,19 @@ public class SoundManager : MonoBehaviour
     // Play a sound effect and set its volume and priority
     public static void PlaySound(SoundType soundType, float volume = 1f, int priority = 128)
     {
+        string clipName = instance.soundList[(int)soundType].name;
+
+        // Check if the sound is already playing and if it is within the minimum interval time don't play it
+        foreach (AudioSource audioSource in instance.audioSourcePool)
+        {
+            if (audioSource.isPlaying && 
+                audioSource.clip.name == clipName && 
+                audioSource.time <= instance.MinSoundInterval)
+            {
+                return; 
+            }
+        }
+
         AudioSource source = instance.GetAvailableAudioSource(priority);
         if (source == null) return; // No available AudioSource
 


### PR DESCRIPTION
Tower asset turned into the fortress prefab for each level. Fixed overlapping sound when multiple of the same sound is requested at once which caused the volume to be very high.